### PR TITLE
[Fix]: 프로필 이미지 저장 경로 수정

### DIFF
--- a/src/main/java/com/ky/docstory/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/ky/docstory/auth/CustomOAuth2UserService.java
@@ -73,7 +73,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String dateDir = LocalDate.now().format(DateTimeFormatter.ofPattern("yy-MM-dd"));
         String saveFilename = UUID.randomUUID() + "." + fileType;
-        String filePath = "/profileImage/" + dateDir + "/" + saveFilename;
+        String filePath = "profileImage/" + dateDir + "/" + saveFilename;
 
         try (InputStream inputStream = url.openStream()) {
             s3Template.upload(bucketName, filePath, inputStream);


### PR DESCRIPTION
## 📄요약

> 기존 S3에 잘못된 경로로 저장되고 있던 이미지 파일의 경로를 수정한다.

## 🖋️작업 내용

- [ ] 프로필 이미지 저장 경로 수정

## 📷스크린샷
![image](https://github.com/user-attachments/assets/f7fe7942-ff69-4db0-ada8-d14771f019e1)

## ❗참고 사항
/ -> 기존에 잘못된 경로
profileImage/ -> 올바르게 설정된 경로

## 🔗이슈
close #18
