### PR TITLE
[Feat]: Repository, Team 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
 	// 파일
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
+
+	// 유효성 검증
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ky/docstory/common/code/DocStoryResponseCode.java
+++ b/src/main/java/com/ky/docstory/common/code/DocStoryResponseCode.java
@@ -30,7 +30,9 @@ public enum DocStoryResponseCode {
     JWT_ILLEGAL(1012, "토큰이 비어있거나 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     JWT_UNAUTHORIZED(1013, "토큰 검증 중 오류가 발생했습니다.", HttpStatus.UNAUTHORIZED),
     UNSUPPORTED_SOCIAL_PROVIDER(1014, "지원하지 않는 소셜 로그인 제공자입니다.", HttpStatus.BAD_REQUEST),
-    USER_NOT_FOUND(1015, "해당 유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    USER_NOT_FOUND(1015, "해당 유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ALREADY_HANDLED(1016, "이미 처리된 요청입니다.", HttpStatus.CONFLICT);
+
 
     private final int code;
     private final String message;

--- a/src/main/java/com/ky/docstory/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ky/docstory/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ky.docstory.common.exception;
 import com.ky.docstory.common.code.DocStoryResponseCode;
 import com.ky.docstory.common.dto.DocStoryResponseBody;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,6 +17,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(DocStoryResponseBody.error(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    // 컨트롤러 유효성 검증
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<DocStoryResponseBody<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        return ResponseEntity
+                .status(DocStoryResponseCode.VALIDATION_ERROR.getHttpStatus())
+                .body(DocStoryResponseBody.error(
+                        DocStoryResponseCode.VALIDATION_ERROR.getCode(),
+                        e.getBindingResult().getAllErrors().get(0).getDefaultMessage() // 첫 번째 메시지만 노출
+                ));
     }
 
     // 그 외 일반 예외 처리

--- a/src/main/java/com/ky/docstory/controller/repository/RepositoryApi.java
+++ b/src/main/java/com/ky/docstory/controller/repository/RepositoryApi.java
@@ -1,0 +1,35 @@
+package com.ky.docstory.controller.repository;
+
+import com.ky.docstory.auth.CurrentUser;
+import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.repository.RepositoryCreateRequest;
+import com.ky.docstory.dto.repository.RepositoryResponse;
+import com.ky.docstory.entity.User;
+import com.ky.docstory.swagger.RepositoryCreateResponseWrapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Repository", description = "레포지토리 관련 API")
+@RequestMapping("/api/repositories")
+public interface RepositoryApi {
+
+    @PostMapping
+    @Operation(summary = "레포지토리 생성", description = "새로운 레포지토리를 생성하고, 생성자는 팀장(ADMIN)으로 등록됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "레포지토리가 성공적으로 생성되었습니다.",
+                    content = @Content(schema = @Schema(implementation = RepositoryCreateResponseWrapper.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.", content = @Content)
+    })
+    ResponseEntity<DocStoryResponseBody<RepositoryResponse>> createRepository(
+            @Parameter(hidden = true) @CurrentUser User currentUser,
+            @RequestBody RepositoryCreateRequest request);
+}

--- a/src/main/java/com/ky/docstory/controller/repository/RepositoryApi.java
+++ b/src/main/java/com/ky/docstory/controller/repository/RepositoryApi.java
@@ -2,13 +2,11 @@ package com.ky.docstory.controller.repository;
 
 import com.ky.docstory.auth.CurrentUser;
 import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.repository.MyRepositoryResponse;
 import com.ky.docstory.dto.repository.RepositoryCreateRequest;
 import com.ky.docstory.dto.repository.RepositoryResponse;
 import com.ky.docstory.entity.User;
-import com.ky.docstory.swagger.BadRequestErrorResponseWrapper;
-import com.ky.docstory.swagger.InternalServerErrorResponseWrapper;
-import com.ky.docstory.swagger.RepositoryCreateResponseWrapper;
-import com.ky.docstory.swagger.UnauthorizedErrorResponseWrapper;
+import com.ky.docstory.swagger.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,6 +17,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Repository", description = "레포지토리 관련 API")
 @RequestMapping("/api/repositories")
@@ -41,4 +41,18 @@ public interface RepositoryApi {
             @Parameter(hidden = true)
             @CurrentUser User currentUser,
             @RequestBody @Valid RepositoryCreateRequest request);
+
+    @Operation(summary = "내가 속한 레포지토리 목록 조회", description = "현재 로그인한 사용자가 속한 모든 레포지토리 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "레포지토리 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = MyRepositoryListResponseWrapper.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = UnauthorizedErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(schema = @Schema(implementation = InternalServerErrorResponseWrapper.class)))
+    })
+    @GetMapping("/my")
+    ResponseEntity<DocStoryResponseBody<List<MyRepositoryResponse>>> getMyRepositories(
+            @Parameter(hidden = true) @CurrentUser User currentUser);
+
 }

--- a/src/main/java/com/ky/docstory/controller/repository/RepositoryApi.java
+++ b/src/main/java/com/ky/docstory/controller/repository/RepositoryApi.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,6 +38,7 @@ public interface RepositoryApi {
 
     })
     ResponseEntity<DocStoryResponseBody<RepositoryResponse>> createRepository(
-            @Parameter(hidden = true) @CurrentUser User currentUser,
-            @RequestBody RepositoryCreateRequest request);
+            @Parameter(hidden = true)
+            @CurrentUser User currentUser,
+            @RequestBody @Valid RepositoryCreateRequest request);
 }

--- a/src/main/java/com/ky/docstory/controller/repository/RepositoryApi.java
+++ b/src/main/java/com/ky/docstory/controller/repository/RepositoryApi.java
@@ -5,7 +5,10 @@ import com.ky.docstory.common.dto.DocStoryResponseBody;
 import com.ky.docstory.dto.repository.RepositoryCreateRequest;
 import com.ky.docstory.dto.repository.RepositoryResponse;
 import com.ky.docstory.entity.User;
+import com.ky.docstory.swagger.BadRequestErrorResponseWrapper;
+import com.ky.docstory.swagger.InternalServerErrorResponseWrapper;
 import com.ky.docstory.swagger.RepositoryCreateResponseWrapper;
+import com.ky.docstory.swagger.UnauthorizedErrorResponseWrapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -25,9 +28,13 @@ public interface RepositoryApi {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "레포지토리가 성공적으로 생성되었습니다.",
                     content = @Content(schema = @Schema(implementation = RepositoryCreateResponseWrapper.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.", content = @Content)
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = BadRequestErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = UnauthorizedErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(schema = @Schema(implementation = InternalServerErrorResponseWrapper.class))),
+
     })
     ResponseEntity<DocStoryResponseBody<RepositoryResponse>> createRepository(
             @Parameter(hidden = true) @CurrentUser User currentUser,

--- a/src/main/java/com/ky/docstory/controller/repository/RepositoryController.java
+++ b/src/main/java/com/ky/docstory/controller/repository/RepositoryController.java
@@ -2,6 +2,7 @@ package com.ky.docstory.controller.repository;
 
 import com.ky.docstory.auth.CurrentUser;
 import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.repository.MyRepositoryResponse;
 import com.ky.docstory.dto.repository.RepositoryCreateRequest;
 import com.ky.docstory.dto.repository.RepositoryResponse;
 import com.ky.docstory.entity.User;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,4 +28,11 @@ public class RepositoryController implements RepositoryApi {
         RepositoryResponse response = repositoryService.createRepository(request, currentUser);
         return ResponseEntity.ok(DocStoryResponseBody.success(response));
     }
+
+    @Override
+    public ResponseEntity<DocStoryResponseBody<List<MyRepositoryResponse>>> getMyRepositories(User currentUser) {
+        List<MyRepositoryResponse> response = repositoryService.getMyRepositories(currentUser);
+        return ResponseEntity.ok(DocStoryResponseBody.success(response));
+    }
+
 }

--- a/src/main/java/com/ky/docstory/controller/repository/RepositoryController.java
+++ b/src/main/java/com/ky/docstory/controller/repository/RepositoryController.java
@@ -1,0 +1,25 @@
+package com.ky.docstory.controller.repository;
+
+import com.ky.docstory.auth.CurrentUser;
+import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.repository.RepositoryCreateRequest;
+import com.ky.docstory.dto.repository.RepositoryResponse;
+import com.ky.docstory.entity.User;
+import com.ky.docstory.service.repository.RepositoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RepositoryController implements RepositoryApi {
+
+    private final RepositoryService repositoryService;
+
+    @Override
+    public ResponseEntity<DocStoryResponseBody<RepositoryResponse>> createRepository(
+            @CurrentUser User currentUser, RepositoryCreateRequest request) {
+        RepositoryResponse response = repositoryService.createRepository(request, currentUser);
+        return ResponseEntity.ok(DocStoryResponseBody.success(response));
+    }
+}

--- a/src/main/java/com/ky/docstory/controller/repository/RepositoryController.java
+++ b/src/main/java/com/ky/docstory/controller/repository/RepositoryController.java
@@ -6,8 +6,10 @@ import com.ky.docstory.dto.repository.RepositoryCreateRequest;
 import com.ky.docstory.dto.repository.RepositoryResponse;
 import com.ky.docstory.entity.User;
 import com.ky.docstory.service.repository.RepositoryService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,7 +20,8 @@ public class RepositoryController implements RepositoryApi {
 
     @Override
     public ResponseEntity<DocStoryResponseBody<RepositoryResponse>> createRepository(
-            @CurrentUser User currentUser, RepositoryCreateRequest request) {
+            @CurrentUser User currentUser,
+            @RequestBody @Valid RepositoryCreateRequest request) {
         RepositoryResponse response = repositoryService.createRepository(request, currentUser);
         return ResponseEntity.ok(DocStoryResponseBody.success(response));
     }

--- a/src/main/java/com/ky/docstory/controller/team/TeamApi.java
+++ b/src/main/java/com/ky/docstory/controller/team/TeamApi.java
@@ -1,0 +1,41 @@
+package com.ky.docstory.controller.team;
+
+import com.ky.docstory.auth.CurrentUser;
+import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.team.TeamMemberResponse;
+import com.ky.docstory.entity.User;
+import com.ky.docstory.swagger.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Team", description = "팀 관련 API")
+@RequestMapping("/api/repositories")
+public interface TeamApi {
+
+    @GetMapping("/{repositoryId}/team-members")
+    @Operation(summary = "팀원 목록 조회", description = "해당 레포지토리에 속한 팀원 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀원 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = TeamMemberListResponseWrapper.class))),
+            @ApiResponse(responseCode = "403", description = "팀원이 아닌 사용자는 조회할 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ForbiddenErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 레포지토리입니다.",
+                    content = @Content(schema = @Schema(implementation = NotFoundErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = InternalServerErrorResponseWrapper.class)))
+    })
+    ResponseEntity<DocStoryResponseBody<List<TeamMemberResponse>>> getTeamMembers(
+            @Parameter(hidden = true) @CurrentUser User currentUser,
+            @PathVariable UUID repositoryId
+    );
+}

--- a/src/main/java/com/ky/docstory/controller/team/TeamApi.java
+++ b/src/main/java/com/ky/docstory/controller/team/TeamApi.java
@@ -2,6 +2,8 @@ package com.ky.docstory.controller.team;
 
 import com.ky.docstory.auth.CurrentUser;
 import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.team.RoleUpdateRequest;
+import com.ky.docstory.dto.team.RoleUpdateResponse;
 import com.ky.docstory.dto.team.TeamMemberResponse;
 import com.ky.docstory.entity.User;
 import com.ky.docstory.swagger.*;
@@ -12,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,4 +41,24 @@ public interface TeamApi {
             @Parameter(hidden = true) @CurrentUser User currentUser,
             @PathVariable UUID repositoryId
     );
+
+    @PutMapping("/{repositoryId}/team-members/{memberId}/role")
+    @Operation(summary = "팀원 권한 변경", description = "ADMIN이 팀원의 권한을 REVIEWER 또는 CONTRIBUTOR로 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "권한 변경 성공",
+                    content = @Content(schema = @Schema(implementation = RoleUpdateResponseWrapper.class))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음 (ADMIN만 가능 또는 자기 자신 권한 변경 시)",
+                    content = @Content(schema = @Schema(implementation = ForbiddenErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "404", description = "레포지토리 또는 팀원을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = NotFoundErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = InternalServerErrorResponseWrapper.class)))
+    })
+    ResponseEntity<DocStoryResponseBody<RoleUpdateResponse>> updateTeamMemberRole(
+            @Parameter(hidden = true) @CurrentUser User currentUser,
+            @PathVariable UUID repositoryId,
+            @PathVariable UUID memberId,
+            @RequestBody @Valid RoleUpdateRequest request
+    );
+
 }

--- a/src/main/java/com/ky/docstory/controller/team/TeamApi.java
+++ b/src/main/java/com/ky/docstory/controller/team/TeamApi.java
@@ -61,4 +61,22 @@ public interface TeamApi {
             @RequestBody @Valid RoleUpdateRequest request
     );
 
+    @Operation(summary = "팀원 추방", description = "ADMIN이 팀원 한 명을 팀에서 추방합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀원 추방 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessEmptyResponseWrapper.class))),
+    @ApiResponse(responseCode = "403", description = "접근 권한 없음 (ADMIN만 가능 또는 자기 자신 추방 불가)",
+                    content = @Content(schema = @Schema(implementation = ForbiddenErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "404", description = "레포지토리 또는 팀원을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = NotFoundErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = InternalServerErrorResponseWrapper.class)))
+    })
+    @DeleteMapping("/{repositoryId}/team-members/{memberId}")
+    ResponseEntity<DocStoryResponseBody<Void>> removeTeamMember(
+            @Parameter(hidden = true) @CurrentUser User currentUser,
+            @PathVariable UUID repositoryId,
+            @PathVariable UUID memberId
+    );
+
 }

--- a/src/main/java/com/ky/docstory/controller/team/TeamController.java
+++ b/src/main/java/com/ky/docstory/controller/team/TeamController.java
@@ -33,4 +33,10 @@ public class TeamController implements TeamApi {
         return ResponseEntity.ok(DocStoryResponseBody.success(response));
     }
 
+    @Override
+    public ResponseEntity<DocStoryResponseBody<Void>> removeTeamMember(User currentUser, UUID repositoryId, UUID memberId) {
+        teamService.removeTeamMember(repositoryId, memberId, currentUser);
+        return ResponseEntity.ok(DocStoryResponseBody.success(null));
+    }
+
 }

--- a/src/main/java/com/ky/docstory/controller/team/TeamController.java
+++ b/src/main/java/com/ky/docstory/controller/team/TeamController.java
@@ -1,0 +1,26 @@
+package com.ky.docstory.controller.team;
+
+import com.ky.docstory.auth.CurrentUser;
+import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.team.TeamMemberResponse;
+import com.ky.docstory.entity.User;
+import com.ky.docstory.service.team.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamController implements TeamApi {
+
+    private final TeamService teamService;
+
+    @Override
+    public ResponseEntity<DocStoryResponseBody<List<TeamMemberResponse>>> getTeamMembers(User currentUser, UUID repositoryId) {
+        List<TeamMemberResponse> response = teamService.getTeamMembers(repositoryId, currentUser);
+        return ResponseEntity.ok(DocStoryResponseBody.success(response));
+    }
+}

--- a/src/main/java/com/ky/docstory/controller/team/TeamController.java
+++ b/src/main/java/com/ky/docstory/controller/team/TeamController.java
@@ -2,6 +2,8 @@ package com.ky.docstory.controller.team;
 
 import com.ky.docstory.auth.CurrentUser;
 import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.team.RoleUpdateRequest;
+import com.ky.docstory.dto.team.RoleUpdateResponse;
 import com.ky.docstory.dto.team.TeamMemberResponse;
 import com.ky.docstory.entity.User;
 import com.ky.docstory.service.team.TeamService;
@@ -23,4 +25,12 @@ public class TeamController implements TeamApi {
         List<TeamMemberResponse> response = teamService.getTeamMembers(repositoryId, currentUser);
         return ResponseEntity.ok(DocStoryResponseBody.success(response));
     }
+
+    @Override
+    public ResponseEntity<DocStoryResponseBody<RoleUpdateResponse>> updateTeamMemberRole(
+            User currentUser, UUID repositoryId, UUID memberId, RoleUpdateRequest request) {
+        RoleUpdateResponse response = teamService.updateTeamMemberRole(repositoryId, memberId, currentUser, request.role());
+        return ResponseEntity.ok(DocStoryResponseBody.success(response));
+    }
+
 }

--- a/src/main/java/com/ky/docstory/controller/teaminvite/TeamInviteApi.java
+++ b/src/main/java/com/ky/docstory/controller/teaminvite/TeamInviteApi.java
@@ -1,0 +1,45 @@
+package com.ky.docstory.controller.teaminvite;
+
+import com.ky.docstory.auth.CurrentUser;
+import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.teaminvite.TeamInviteRequest;
+import com.ky.docstory.dto.teaminvite.TeamInviteResponse;
+import com.ky.docstory.entity.User;
+import com.ky.docstory.swagger.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "TeamInvite", description = "팀 초대 관련 API")
+@RequestMapping("/api/team-invites")
+public interface TeamInviteApi {
+
+    @PostMapping
+    @Operation(summary = "레포지토리 팀원 초대", description = "레포지토리의 팀원으로 사용자를 초대합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "초대가 성공적으로 완료되었습니다.",
+                    content = @Content(schema = @Schema(implementation = TeamInviteResponseWrapper.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = BadRequestErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = UnauthorizedErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "403", description = "레포지토리 권한이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ForbiddenErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 또는 레포지토리를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = NotFoundErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "409", description = "이미 초대한 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = DuplicateResourceErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(schema = @Schema(implementation = InternalServerErrorResponseWrapper.class)))
+    })
+    ResponseEntity<DocStoryResponseBody<TeamInviteResponse>> inviteUser(
+            @Parameter(hidden = true) @CurrentUser User currentUser,
+            @RequestBody @Valid TeamInviteRequest request);
+}

--- a/src/main/java/com/ky/docstory/controller/teaminvite/TeamInviteApi.java
+++ b/src/main/java/com/ky/docstory/controller/teaminvite/TeamInviteApi.java
@@ -17,6 +17,8 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @Tag(name = "TeamInvite", description = "팀 초대 관련 API")
 @RequestMapping("/api/team-invites")
 public interface TeamInviteApi {
@@ -42,4 +44,41 @@ public interface TeamInviteApi {
     ResponseEntity<DocStoryResponseBody<TeamInviteResponse>> inviteUser(
             @Parameter(hidden = true) @CurrentUser User currentUser,
             @RequestBody @Valid TeamInviteRequest request);
+
+    @Operation(summary = "초대 수락", description = "사용자가 받은 초대를 수락합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "초대 수락 완료",
+                    content = @Content(schema = @Schema(implementation = TeamInviteResponseWrapper.class))),
+            @ApiResponse(responseCode = "403", description = "초대받은 사용자가 아닙니다.",
+                    content = @Content(schema = @Schema(implementation = ForbiddenErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "404", description = "초대를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = NotFoundErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "409", description = "이미 수락/거절된 초대입니다.",
+                    content = @Content(schema = @Schema(implementation = AlreadyHandledErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = InternalServerErrorResponseWrapper.class)))
+    })
+    @PostMapping("/{inviteId}/accept")
+    ResponseEntity<DocStoryResponseBody<TeamInviteResponse>> acceptInvite(
+            @Parameter(hidden = true) @CurrentUser User currentUser,
+            @PathVariable UUID inviteId);
+
+    @Operation(summary = "초대 거절", description = "사용자가 받은 초대를 거절합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "초대 거절 완료",
+                    content = @Content(schema = @Schema(implementation = TeamInviteResponseWrapper.class))),
+            @ApiResponse(responseCode = "403", description = "초대받은 사용자가 아닙니다.",
+                    content = @Content(schema = @Schema(implementation = ForbiddenErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "404", description = "초대를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = NotFoundErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "409", description = "이미 수락/거절된 초대입니다.",
+                    content = @Content(schema = @Schema(implementation = AlreadyHandledErrorResponseWrapper.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = InternalServerErrorResponseWrapper.class)))
+    })
+    @PostMapping("/{inviteId}/reject")
+    ResponseEntity<DocStoryResponseBody<TeamInviteResponse>> rejectInvite(
+            @Parameter(hidden = true) @CurrentUser User currentUser,
+            @PathVariable UUID inviteId);
+
 }

--- a/src/main/java/com/ky/docstory/controller/teaminvite/TeamInviteController.java
+++ b/src/main/java/com/ky/docstory/controller/teaminvite/TeamInviteController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 public class TeamInviteController implements TeamInviteApi {
@@ -23,4 +25,17 @@ public class TeamInviteController implements TeamInviteApi {
         TeamInviteResponse response = teamInviteService.inviteUserToRepository(request, currentUser);
         return ResponseEntity.ok(DocStoryResponseBody.success(response));
     }
+
+    @Override
+    public ResponseEntity<DocStoryResponseBody<TeamInviteResponse>> acceptInvite(User currentUser, UUID inviteId) {
+        TeamInviteResponse response = teamInviteService.acceptInvite(inviteId, currentUser);
+        return ResponseEntity.ok(DocStoryResponseBody.success(response));
+    }
+
+    @Override
+    public ResponseEntity<DocStoryResponseBody<TeamInviteResponse>> rejectInvite(User currentUser, UUID inviteId) {
+        TeamInviteResponse response = teamInviteService.rejectInvite(inviteId, currentUser);
+        return ResponseEntity.ok(DocStoryResponseBody.success(response));
+    }
+
 }

--- a/src/main/java/com/ky/docstory/controller/teaminvite/TeamInviteController.java
+++ b/src/main/java/com/ky/docstory/controller/teaminvite/TeamInviteController.java
@@ -1,0 +1,26 @@
+package com.ky.docstory.controller.teaminvite;
+
+import com.ky.docstory.auth.CurrentUser;
+import com.ky.docstory.common.dto.DocStoryResponseBody;
+import com.ky.docstory.dto.teaminvite.TeamInviteRequest;
+import com.ky.docstory.dto.teaminvite.TeamInviteResponse;
+import com.ky.docstory.entity.User;
+import com.ky.docstory.service.teaminvite.TeamInviteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamInviteController implements TeamInviteApi {
+
+    private final TeamInviteService teamInviteService;
+
+    @Override
+    public ResponseEntity<DocStoryResponseBody<TeamInviteResponse>> inviteUser(
+            User currentUser,
+            TeamInviteRequest request) {
+        TeamInviteResponse response = teamInviteService.inviteUserToRepository(request, currentUser);
+        return ResponseEntity.ok(DocStoryResponseBody.success(response));
+    }
+}

--- a/src/main/java/com/ky/docstory/dto/repository/MyRepositoryResponse.java
+++ b/src/main/java/com/ky/docstory/dto/repository/MyRepositoryResponse.java
@@ -1,0 +1,35 @@
+package com.ky.docstory.dto.repository;
+
+import com.ky.docstory.entity.Team;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "내가 속한 레포지토리 응답 DTO")
+public record MyRepositoryResponse(
+
+        @Schema(description = "레포지토리 ID", example = "3c1a0ab4-0b90-4db4-b8e0-1ef2b6db1944")
+        UUID id,
+
+        @Schema(description = "레포지토리 이름", example = "docstory-core")
+        String name,
+
+        @Schema(description = "레포지토리 설명", example = "협업용 문서 저장소")
+        String description,
+
+        @Schema(description = "소유자 닉네임", example = "kanguk")
+        String ownerNickname,
+
+        @Schema(description = "내 역할", example = "CONTRIBUTOR")
+        Team.Role myRole
+) {
+    public static MyRepositoryResponse from(Team team) {
+        return new MyRepositoryResponse(
+                team.getRepository().getId(),
+                team.getRepository().getName(),
+                team.getRepository().getDescription(),
+                team.getRepository().getOwner().getNickname(),
+                team.getRole()
+        );
+    }
+}

--- a/src/main/java/com/ky/docstory/dto/repository/RepositoryCreateRequest.java
+++ b/src/main/java/com/ky/docstory/dto/repository/RepositoryCreateRequest.java
@@ -1,13 +1,18 @@
 package com.ky.docstory.dto.repository;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "레포지토리 생성 요청 DTO")
 public record RepositoryCreateRequest(
 
+        @NotBlank(message = "레포지토리 이름은 필수입니다.")
+        @Size(max = 255, message = "레포지토리 이름은 255자 이하여야 합니다.")
         @Schema(description = "레포지토리 이름", example = "docstory-project", required = true)
         String name,
 
+        @Size(max = 2000, message = "설명은 2000자 이하여야 합니다.")
         @Schema(description = "레포지토리 설명", example = "팀 협업을 위한 문서 저장소", required = false)
         String description
 ) {}

--- a/src/main/java/com/ky/docstory/dto/repository/RepositoryCreateRequest.java
+++ b/src/main/java/com/ky/docstory/dto/repository/RepositoryCreateRequest.java
@@ -1,0 +1,13 @@
+package com.ky.docstory.dto.repository;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "레포지토리 생성 요청 DTO")
+public record RepositoryCreateRequest(
+
+        @Schema(description = "레포지토리 이름", example = "docstory-project", required = true)
+        String name,
+
+        @Schema(description = "레포지토리 설명", example = "팀 협업을 위한 문서 저장소", required = false)
+        String description
+) {}

--- a/src/main/java/com/ky/docstory/dto/repository/RepositoryResponse.java
+++ b/src/main/java/com/ky/docstory/dto/repository/RepositoryResponse.java
@@ -1,0 +1,31 @@
+package com.ky.docstory.dto.repository;
+
+import com.ky.docstory.entity.Repository;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "레포지토리 응답 DTO")
+public record RepositoryResponse(
+
+        @Schema(description = "레포지토리 ID", example = "9593d6b7-8e22-43be-a5bc-c586dfed0eb3")
+        UUID id,
+
+        @Schema(description = "레포지토리 이름", example = "docstory-project")
+        String name,
+
+        @Schema(description = "레포지토리 설명", example = "팀 협업을 위한 문서 저장소")
+        String description,
+
+        @Schema(description = "레포지토리 소유자 닉네임", example = "강욱")
+        String ownerNickname
+) {
+    public static RepositoryResponse from(Repository repository) {
+        return new RepositoryResponse(
+                repository.getId(),
+                repository.getName(),
+                repository.getDescription(),
+                repository.getOwner().getNickname()
+        );
+    }
+}

--- a/src/main/java/com/ky/docstory/dto/team/RoleUpdateRequest.java
+++ b/src/main/java/com/ky/docstory/dto/team/RoleUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.ky.docstory.dto.team;
+
+import com.ky.docstory.entity.Team;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "팀원 권한 변경 요청 DTO")
+public record RoleUpdateRequest(
+        @Schema(description = "변경할 권한", example = "REVIEWER", required = true)
+        Team.Role role
+) {}

--- a/src/main/java/com/ky/docstory/dto/team/RoleUpdateResponse.java
+++ b/src/main/java/com/ky/docstory/dto/team/RoleUpdateResponse.java
@@ -1,0 +1,21 @@
+package com.ky.docstory.dto.team;
+
+import com.ky.docstory.entity.Team;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "팀원 권한 변경 응답 DTO")
+public record RoleUpdateResponse(
+        @Schema(description = "사용자 ID") UUID userId,
+        @Schema(description = "닉네임") String nickname,
+        @Schema(description = "변경된 역할") Team.Role role
+) {
+    public static RoleUpdateResponse from(Team team) {
+        return new RoleUpdateResponse(
+                team.getUser().getId(),
+                team.getUser().getNickname(),
+                team.getRole()
+        );
+    }
+}

--- a/src/main/java/com/ky/docstory/dto/team/TeamMemberResponse.java
+++ b/src/main/java/com/ky/docstory/dto/team/TeamMemberResponse.java
@@ -1,0 +1,31 @@
+package com.ky.docstory.dto.team;
+
+import com.ky.docstory.entity.Team;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "팀원 목록 응답 DTO")
+public record TeamMemberResponse(
+
+        @Schema(description = "팀원 ID", example = "ebdbeb92-1234-44fe-b78b-0d2e613f65a3")
+        UUID userId,
+
+        @Schema(description = "팀원 닉네임", example = "kanguk")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 경로", example = "https://example.com/profile.jpg")
+        String profileImage,
+
+        @Schema(description = "팀원 역할", example = "CONTRIBUTOR")
+        String role
+) {
+    public static TeamMemberResponse from(Team team) {
+        return new TeamMemberResponse(
+                team.getUser().getId(),
+                team.getUser().getNickname(),
+                team.getUser().getProfilePath(),
+                team.getRole().name()
+        );
+    }
+}

--- a/src/main/java/com/ky/docstory/dto/teaminvite/TeamInviteRequest.java
+++ b/src/main/java/com/ky/docstory/dto/teaminvite/TeamInviteRequest.java
@@ -1,0 +1,18 @@
+package com.ky.docstory.dto.teaminvite;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+@Schema(description = "팀 초대 요청 DTO")
+public record TeamInviteRequest(
+
+        @NotNull(message = "레포지토리 ID는 필수입니다.")
+        @Schema(description = "레포지토리 ID", example = "7f310b23-f68d-4c4f-9910-94c96f00a4b2")
+        UUID repositoryId,
+
+        @NotNull(message = "초대 대상 사용자 ID는 필수입니다.")
+        @Schema(description = "초대할 사용자 ID", example = "3e1192a9-3244-46ef-bc88-8de938974a9a")
+        UUID inviteeId
+) {}

--- a/src/main/java/com/ky/docstory/dto/teaminvite/TeamInviteResponse.java
+++ b/src/main/java/com/ky/docstory/dto/teaminvite/TeamInviteResponse.java
@@ -1,0 +1,20 @@
+package com.ky.docstory.dto.teaminvite;
+
+import com.ky.docstory.entity.TeamInvite;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "팀 초대 응답 DTO")
+public record TeamInviteResponse(
+
+        @Schema(description = "초대 ID", example = "1e7b38f0-33aa-4b3e-9122-1fcae4032a65")
+        UUID inviteId,
+
+        @Schema(description = "초대 상태", example = "PENDING")
+        String status
+) {
+    public static TeamInviteResponse from(TeamInvite invite) {
+        return new TeamInviteResponse(invite.getId(), invite.getStatus().name());
+    }
+}

--- a/src/main/java/com/ky/docstory/entity/Team.java
+++ b/src/main/java/com/ky/docstory/entity/Team.java
@@ -29,4 +29,9 @@ public class Team extends BaseEntity {
         REVIEWER,
         CONTRIBUTOR
     }
+
+    public void changeRole(Role newRole) {
+        this.role = newRole;
+    }
+
 }

--- a/src/main/java/com/ky/docstory/entity/TeamInvite.java
+++ b/src/main/java/com/ky/docstory/entity/TeamInvite.java
@@ -1,0 +1,38 @@
+package com.ky.docstory.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Table(name = "team_invite", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"repository_id", "invitee_id"})
+})
+public class TeamInvite extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "repository_id", nullable = false)
+    private Repository repository;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id", nullable = false)
+    private User inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitee_id", nullable = false)
+    private User invitee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
+
+    public enum Status {
+        PENDING,
+        ACCEPTED,
+        REJECTED
+    }
+}

--- a/src/main/java/com/ky/docstory/entity/TeamInvite.java
+++ b/src/main/java/com/ky/docstory/entity/TeamInvite.java
@@ -1,5 +1,7 @@
 package com.ky.docstory.entity;
 
+import com.ky.docstory.common.code.DocStoryResponseCode;
+import com.ky.docstory.common.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,5 +36,19 @@ public class TeamInvite extends BaseEntity {
         PENDING,
         ACCEPTED,
         REJECTED
+    }
+
+    public void accept() {
+        if (this.status != Status.PENDING) {
+            throw new BusinessException(DocStoryResponseCode.ALREADY_HANDLED);
+        }
+        this.status = Status.ACCEPTED;
+    }
+
+    public void reject() {
+        if (this.status != Status.PENDING) {
+            throw new BusinessException(DocStoryResponseCode.ALREADY_HANDLED);
+        }
+        this.status = Status.REJECTED;
     }
 }

--- a/src/main/java/com/ky/docstory/repository/RepositoryRepository.java
+++ b/src/main/java/com/ky/docstory/repository/RepositoryRepository.java
@@ -1,0 +1,9 @@
+package com.ky.docstory.repository;
+
+import com.ky.docstory.entity.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RepositoryRepository extends JpaRepository<Repository, UUID> {
+}

--- a/src/main/java/com/ky/docstory/repository/TeamInviteRepository.java
+++ b/src/main/java/com/ky/docstory/repository/TeamInviteRepository.java
@@ -1,0 +1,15 @@
+package com.ky.docstory.repository;
+
+import com.ky.docstory.entity.Repository;
+import com.ky.docstory.entity.TeamInvite;
+import com.ky.docstory.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TeamInviteRepository extends JpaRepository<TeamInvite, UUID> {
+    boolean existsByRepositoryAndInvitee(Repository repository, User invitee);
+
+    Optional<TeamInvite> findByRepositoryAndInvitee(Repository repository, User invitee);
+}

--- a/src/main/java/com/ky/docstory/repository/TeamRepository.java
+++ b/src/main/java/com/ky/docstory/repository/TeamRepository.java
@@ -23,4 +23,7 @@ public interface TeamRepository extends JpaRepository<Team, UUID> {
 
     Optional<Team> findByRepositoryAndUserId(Repository repository, UUID userId);
 
+    @Query("SELECT t FROM Team t JOIN FETCH t.repository r JOIN FETCH r.owner WHERE t.user = :user")
+    List<Team> findAllByUserWithRepository(@Param("user") User user);
+
 }

--- a/src/main/java/com/ky/docstory/repository/TeamRepository.java
+++ b/src/main/java/com/ky/docstory/repository/TeamRepository.java
@@ -6,9 +6,16 @@ import com.ky.docstory.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface TeamRepository extends JpaRepository<Team, UUID> {
     boolean existsByRepositoryAndUser(Repository repository, User user);
+
     List<Team> findAllByRepository(Repository repository);
+
+    Optional<Team> findByRepositoryAndUser(Repository repository, User user);
+
+    Optional<Team> findByRepositoryAndUserId(Repository repository, UUID userId);
+
 }

--- a/src/main/java/com/ky/docstory/repository/TeamRepository.java
+++ b/src/main/java/com/ky/docstory/repository/TeamRepository.java
@@ -1,9 +1,14 @@
 package com.ky.docstory.repository;
 
+import com.ky.docstory.entity.Repository;
 import com.ky.docstory.entity.Team;
+import com.ky.docstory.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface TeamRepository extends JpaRepository<Team, UUID> {
+    boolean existsByRepositoryAndUser(Repository repository, User user);
+    List<Team> findAllByRepository(Repository repository);
 }

--- a/src/main/java/com/ky/docstory/repository/TeamRepository.java
+++ b/src/main/java/com/ky/docstory/repository/TeamRepository.java
@@ -1,0 +1,9 @@
+package com.ky.docstory.repository;
+
+import com.ky.docstory.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TeamRepository extends JpaRepository<Team, UUID> {
+}

--- a/src/main/java/com/ky/docstory/repository/TeamRepository.java
+++ b/src/main/java/com/ky/docstory/repository/TeamRepository.java
@@ -4,6 +4,8 @@ import com.ky.docstory.entity.Repository;
 import com.ky.docstory.entity.Team;
 import com.ky.docstory.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +13,9 @@ import java.util.UUID;
 
 public interface TeamRepository extends JpaRepository<Team, UUID> {
     boolean existsByRepositoryAndUser(Repository repository, User user);
+
+    @Query("SELECT t FROM Team t JOIN FETCH t.user WHERE t.repository = :repository")
+    List<Team> findAllByRepositoryWithUser(@Param("repository") Repository repository);
 
     List<Team> findAllByRepository(Repository repository);
 

--- a/src/main/java/com/ky/docstory/repository/UserRepository.java
+++ b/src/main/java/com/ky/docstory/repository/UserRepository.java
@@ -2,8 +2,10 @@ package com.ky.docstory.repository;
 
 import com.ky.docstory.entity.User;
 import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByProviderId(String providerId);
 }

--- a/src/main/java/com/ky/docstory/service/repository/RepositoryService.java
+++ b/src/main/java/com/ky/docstory/service/repository/RepositoryService.java
@@ -1,9 +1,15 @@
 package com.ky.docstory.service.repository;
 
+import com.ky.docstory.dto.repository.MyRepositoryResponse;
 import com.ky.docstory.dto.repository.RepositoryCreateRequest;
 import com.ky.docstory.dto.repository.RepositoryResponse;
 import com.ky.docstory.entity.User;
 
+import java.util.List;
+
 public interface RepositoryService {
     RepositoryResponse createRepository(RepositoryCreateRequest request, User owner);
+
+    List<MyRepositoryResponse> getMyRepositories(User currentUser);
+
 }

--- a/src/main/java/com/ky/docstory/service/repository/RepositoryService.java
+++ b/src/main/java/com/ky/docstory/service/repository/RepositoryService.java
@@ -1,0 +1,9 @@
+package com.ky.docstory.service.repository;
+
+import com.ky.docstory.dto.repository.RepositoryCreateRequest;
+import com.ky.docstory.dto.repository.RepositoryResponse;
+import com.ky.docstory.entity.User;
+
+public interface RepositoryService {
+    RepositoryResponse createRepository(RepositoryCreateRequest request, User owner);
+}

--- a/src/main/java/com/ky/docstory/service/repository/RepositoryServiceImpl.java
+++ b/src/main/java/com/ky/docstory/service/repository/RepositoryServiceImpl.java
@@ -1,0 +1,42 @@
+package com.ky.docstory.service.repository;
+
+import com.ky.docstory.dto.repository.RepositoryCreateRequest;
+import com.ky.docstory.dto.repository.RepositoryResponse;
+import com.ky.docstory.entity.Repository;
+import com.ky.docstory.entity.Team;
+import com.ky.docstory.entity.User;
+import com.ky.docstory.repository.TeamRepository;
+import com.ky.docstory.repository.RepositoryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RepositoryServiceImpl implements RepositoryService {
+
+    private final RepositoryRepository repositoryRepository;
+    private final TeamRepository teamRepository;
+
+    @Override
+    @Transactional
+    public RepositoryResponse createRepository(RepositoryCreateRequest request, User owner) {
+        Repository repository = Repository.builder()
+                .name(request.name())
+                .description(request.description())
+                .owner(owner)
+                .build();
+
+        repositoryRepository.save(repository);
+
+        Team team = Team.builder()
+                .repository(repository)
+                .user(owner)
+                .role(Team.Role.ADMIN)
+                .build();
+
+        teamRepository.save(team);
+
+        return RepositoryResponse.from(repository);
+    }
+}

--- a/src/main/java/com/ky/docstory/service/repository/RepositoryServiceImpl.java
+++ b/src/main/java/com/ky/docstory/service/repository/RepositoryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ky.docstory.service.repository;
 
+import com.ky.docstory.dto.repository.MyRepositoryResponse;
 import com.ky.docstory.dto.repository.RepositoryCreateRequest;
 import com.ky.docstory.dto.repository.RepositoryResponse;
 import com.ky.docstory.entity.Repository;
@@ -10,6 +11,8 @@ import com.ky.docstory.repository.RepositoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -39,4 +42,14 @@ public class RepositoryServiceImpl implements RepositoryService {
 
         return RepositoryResponse.from(repository);
     }
+
+    @Override
+    @Transactional
+    public List<MyRepositoryResponse> getMyRepositories(User currentUser) {
+        List<Team> myTeams = teamRepository.findAllByUserWithRepository(currentUser);
+        return myTeams.stream()
+                .map(MyRepositoryResponse::from)
+                .toList();
+    }
+
 }

--- a/src/main/java/com/ky/docstory/service/team/TeamService.java
+++ b/src/main/java/com/ky/docstory/service/team/TeamService.java
@@ -10,5 +10,9 @@ import java.util.UUID;
 
 public interface TeamService {
     List<TeamMemberResponse> getTeamMembers(UUID repositoryId, User currentUser);
+
     RoleUpdateResponse updateTeamMemberRole(UUID repositoryId, UUID memberId, User currentUser, Team.Role newRole);
+
+    void removeTeamMember(UUID repositoryId, UUID memberId, User currentUser);
+
 }

--- a/src/main/java/com/ky/docstory/service/team/TeamService.java
+++ b/src/main/java/com/ky/docstory/service/team/TeamService.java
@@ -1,6 +1,8 @@
 package com.ky.docstory.service.team;
 
+import com.ky.docstory.dto.team.RoleUpdateResponse;
 import com.ky.docstory.dto.team.TeamMemberResponse;
+import com.ky.docstory.entity.Team;
 import com.ky.docstory.entity.User;
 
 import java.util.List;
@@ -8,4 +10,5 @@ import java.util.UUID;
 
 public interface TeamService {
     List<TeamMemberResponse> getTeamMembers(UUID repositoryId, User currentUser);
+    RoleUpdateResponse updateTeamMemberRole(UUID repositoryId, UUID memberId, User currentUser, Team.Role newRole);
 }

--- a/src/main/java/com/ky/docstory/service/team/TeamService.java
+++ b/src/main/java/com/ky/docstory/service/team/TeamService.java
@@ -1,0 +1,11 @@
+package com.ky.docstory.service.team;
+
+import com.ky.docstory.dto.team.TeamMemberResponse;
+import com.ky.docstory.entity.User;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TeamService {
+    List<TeamMemberResponse> getTeamMembers(UUID repositoryId, User currentUser);
+}

--- a/src/main/java/com/ky/docstory/service/team/TeamServiceImpl.java
+++ b/src/main/java/com/ky/docstory/service/team/TeamServiceImpl.java
@@ -2,12 +2,14 @@ package com.ky.docstory.service.team;
 
 import com.ky.docstory.common.code.DocStoryResponseCode;
 import com.ky.docstory.common.exception.BusinessException;
+import com.ky.docstory.dto.team.RoleUpdateResponse;
 import com.ky.docstory.dto.team.TeamMemberResponse;
 import com.ky.docstory.entity.Repository;
 import com.ky.docstory.entity.Team;
 import com.ky.docstory.entity.User;
 import com.ky.docstory.repository.RepositoryRepository;
 import com.ky.docstory.repository.TeamRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -35,4 +37,30 @@ public class TeamServiceImpl implements TeamService {
                 .map(TeamMemberResponse::from)
                 .toList();
     }
+
+    @Override
+    @Transactional
+    public RoleUpdateResponse updateTeamMemberRole(UUID repositoryId, UUID memberId, User currentUser, Team.Role newRole) {
+        Repository repository = repositoryRepository.findById(repositoryId)
+                .orElseThrow(() -> new BusinessException(DocStoryResponseCode.NOT_FOUND));
+
+        Team currentTeam = teamRepository.findByRepositoryAndUser(repository, currentUser)
+                .orElseThrow(() -> new BusinessException(DocStoryResponseCode.FORBIDDEN));
+
+        if (currentTeam.getRole() != Team.Role.ADMIN) {
+            throw new BusinessException(DocStoryResponseCode.FORBIDDEN);
+        }
+
+        if (currentUser.getId().equals(memberId)) {
+            throw new BusinessException(DocStoryResponseCode.FORBIDDEN); // 본인 권한 수정 불가
+        }
+
+        Team targetTeam = teamRepository.findByRepositoryAndUserId(repository, memberId)
+                .orElseThrow(() -> new BusinessException(DocStoryResponseCode.NOT_FOUND));
+
+        targetTeam.changeRole(newRole);
+
+        return RoleUpdateResponse.from(targetTeam);
+    }
+
 }

--- a/src/main/java/com/ky/docstory/service/team/TeamServiceImpl.java
+++ b/src/main/java/com/ky/docstory/service/team/TeamServiceImpl.java
@@ -1,0 +1,38 @@
+package com.ky.docstory.service.team;
+
+import com.ky.docstory.common.code.DocStoryResponseCode;
+import com.ky.docstory.common.exception.BusinessException;
+import com.ky.docstory.dto.team.TeamMemberResponse;
+import com.ky.docstory.entity.Repository;
+import com.ky.docstory.entity.Team;
+import com.ky.docstory.entity.User;
+import com.ky.docstory.repository.RepositoryRepository;
+import com.ky.docstory.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TeamServiceImpl implements TeamService {
+
+    private final TeamRepository teamRepository;
+    private final RepositoryRepository repositoryRepository;
+
+    @Override
+    public List<TeamMemberResponse> getTeamMembers(UUID repositoryId, User currentUser) {
+        Repository repository = repositoryRepository.findById(repositoryId)
+                .orElseThrow(() -> new BusinessException(DocStoryResponseCode.NOT_FOUND));
+
+        boolean isMember = teamRepository.existsByRepositoryAndUser(repository, currentUser);
+        if (!isMember) {
+            throw new BusinessException(DocStoryResponseCode.FORBIDDEN);
+        }
+
+        return teamRepository.findAllByRepository(repository).stream()
+                .map(TeamMemberResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteService.java
+++ b/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteService.java
@@ -1,0 +1,9 @@
+package com.ky.docstory.service.teaminvite;
+
+import com.ky.docstory.dto.teaminvite.TeamInviteRequest;
+import com.ky.docstory.dto.teaminvite.TeamInviteResponse;
+import com.ky.docstory.entity.User;
+
+public interface TeamInviteService {
+    TeamInviteResponse inviteUserToRepository(TeamInviteRequest request, User inviter);
+}

--- a/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteService.java
+++ b/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteService.java
@@ -4,6 +4,13 @@ import com.ky.docstory.dto.teaminvite.TeamInviteRequest;
 import com.ky.docstory.dto.teaminvite.TeamInviteResponse;
 import com.ky.docstory.entity.User;
 
+import java.util.UUID;
+
 public interface TeamInviteService {
     TeamInviteResponse inviteUserToRepository(TeamInviteRequest request, User inviter);
+
+    TeamInviteResponse acceptInvite(UUID inviteId, User currentUser);
+
+    TeamInviteResponse rejectInvite(UUID inviteId, User currentUser);
+
 }

--- a/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteServiceImpl.java
+++ b/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteServiceImpl.java
@@ -7,11 +7,14 @@ import com.ky.docstory.dto.teaminvite.TeamInviteResponse;
 import com.ky.docstory.entity.*;
 import com.ky.docstory.repository.RepositoryRepository;
 import com.ky.docstory.repository.TeamInviteRepository;
+import com.ky.docstory.repository.TeamRepository;
 import com.ky.docstory.repository.UserRepository;
 import com.ky.docstory.service.teaminvite.TeamInviteService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +23,7 @@ public class TeamInviteServiceImpl implements TeamInviteService {
     private final RepositoryRepository repositoryRepository;
     private final TeamInviteRepository teamInviteRepository;
     private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
 
     @Override
     @Transactional
@@ -53,4 +57,43 @@ public class TeamInviteServiceImpl implements TeamInviteService {
 
         return TeamInviteResponse.from(invite);
     }
+
+    @Override
+    @Transactional
+    public TeamInviteResponse acceptInvite(UUID inviteId, User currentUser) {
+        TeamInvite invite = teamInviteRepository.findById(inviteId)
+                .orElseThrow(() -> new BusinessException(DocStoryResponseCode.NOT_FOUND));
+
+        if (!invite.getInvitee().getId().equals(currentUser.getId())) {
+            throw new BusinessException(DocStoryResponseCode.FORBIDDEN);
+        }
+
+        invite.accept();
+
+        Team team = Team.builder()
+                .repository(invite.getRepository())
+                .user(currentUser)
+                .role(Team.Role.CONTRIBUTOR)
+                .build();
+
+        teamRepository.save(team);
+
+        return TeamInviteResponse.from(invite);
+    }
+
+    @Override
+    @Transactional
+    public TeamInviteResponse rejectInvite(UUID inviteId, User currentUser) {
+        TeamInvite invite = teamInviteRepository.findById(inviteId)
+                .orElseThrow(() -> new BusinessException(DocStoryResponseCode.NOT_FOUND));
+
+        if (!invite.getInvitee().getId().equals(currentUser.getId())) {
+            throw new BusinessException(DocStoryResponseCode.FORBIDDEN);
+        }
+
+        invite.reject();
+
+        return TeamInviteResponse.from(invite);
+    }
+
 }

--- a/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteServiceImpl.java
+++ b/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteServiceImpl.java
@@ -1,0 +1,56 @@
+package com.ky.docstory.service.teaminvite;
+
+import com.ky.docstory.common.code.DocStoryResponseCode;
+import com.ky.docstory.common.exception.BusinessException;
+import com.ky.docstory.dto.teaminvite.TeamInviteRequest;
+import com.ky.docstory.dto.teaminvite.TeamInviteResponse;
+import com.ky.docstory.entity.*;
+import com.ky.docstory.repository.RepositoryRepository;
+import com.ky.docstory.repository.TeamInviteRepository;
+import com.ky.docstory.repository.UserRepository;
+import com.ky.docstory.service.teaminvite.TeamInviteService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TeamInviteServiceImpl implements TeamInviteService {
+
+    private final RepositoryRepository repositoryRepository;
+    private final TeamInviteRepository teamInviteRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public TeamInviteResponse inviteUserToRepository(TeamInviteRequest request, User inviter) {
+        Repository repository = repositoryRepository.findById(request.repositoryId())
+                .orElseThrow(() -> new BusinessException(DocStoryResponseCode.NOT_FOUND));
+
+        if (!repository.getOwner().getId().equals(inviter.getId())) {
+            throw new BusinessException(DocStoryResponseCode.FORBIDDEN);
+        }
+
+        if (inviter.getId().equals(request.inviteeId())) {
+            throw new BusinessException(DocStoryResponseCode.PARAMETER_ERROR);
+        }
+
+        User invitee = userRepository.findById(request.inviteeId())
+                .orElseThrow(() -> new BusinessException(DocStoryResponseCode.NOT_FOUND));
+
+        if (teamInviteRepository.existsByRepositoryAndInvitee(repository, invitee)) {
+            throw new BusinessException(DocStoryResponseCode.DUPLICATE_RESOURCE);
+        }
+
+        TeamInvite invite = TeamInvite.builder()
+                .repository(repository)
+                .inviter(inviter)
+                .invitee(invitee)
+                .status(TeamInvite.Status.PENDING)
+                .build();
+
+        teamInviteRepository.save(invite);
+
+        return TeamInviteResponse.from(invite);
+    }
+}

--- a/src/main/java/com/ky/docstory/swagger/AlreadyHandledErrorResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/AlreadyHandledErrorResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.ky.docstory.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이미 처리된 요청에 대한 에러 응답 예시")
+public class AlreadyHandledErrorResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "1016")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "이미 처리된 요청입니다.")
+    public String message;
+
+    @Schema(description = "응답 데이터", nullable = true)
+    public Object data;
+}

--- a/src/main/java/com/ky/docstory/swagger/BadRequestErrorResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/BadRequestErrorResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.ky.docstory.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "400 잘못된 요청 응답")
+public class BadRequestErrorResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "400")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "잘못된 요청입니다.")
+    public String message;
+
+    @Schema(description = "응답 데이터", example = "null")
+    public Object data;
+}

--- a/src/main/java/com/ky/docstory/swagger/DuplicateResourceErrorResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/DuplicateResourceErrorResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.ky.docstory.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "409 요청 충돌 응답")
+public class DuplicateResourceErrorResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "409")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "요청이 서버와 충돌하였습니다.")
+    public String message;
+
+    @Schema(description = "응답 데이터", example = "null")
+    public Object data;
+}

--- a/src/main/java/com/ky/docstory/swagger/ForbiddenErrorResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/ForbiddenErrorResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.ky.docstory.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "403 권한 없음 응답")
+public class ForbiddenErrorResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "403")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "접근 권한이 없습니다.")
+    public String message;
+
+    @Schema(description = "응답 데이터", example = "null")
+    public Object data;
+}

--- a/src/main/java/com/ky/docstory/swagger/InternalServerErrorResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/InternalServerErrorResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.ky.docstory.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "500 서버 내부 오류 응답")
+public class InternalServerErrorResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "500")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "서버 내부 오류가 발생했습니다.")
+    public String message;
+
+    @Schema(description = "응답 데이터", example = "null")
+    public Object data;
+}

--- a/src/main/java/com/ky/docstory/swagger/MyRepositoryListResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/MyRepositoryListResponseWrapper.java
@@ -1,0 +1,19 @@
+package com.ky.docstory.swagger;
+
+import com.ky.docstory.dto.repository.MyRepositoryResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "내 레포지토리 목록 응답 Wrapper")
+public class MyRepositoryListResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "100")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다.")
+    public String message;
+
+    @Schema(description = "레포지토리 목록 데이터")
+    public List<MyRepositoryResponse> data;
+}

--- a/src/main/java/com/ky/docstory/swagger/NotFoundErrorResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/NotFoundErrorResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.ky.docstory.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "404 리소스 없음 응답")
+public class NotFoundErrorResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "404")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "요청한 리소스를 찾을 수 없습니다.")
+    public String message;
+
+    @Schema(description = "응답 데이터", example = "null")
+    public Object data;
+}

--- a/src/main/java/com/ky/docstory/swagger/RepositoryCreateResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/RepositoryCreateResponseWrapper.java
@@ -1,0 +1,17 @@
+package com.ky.docstory.swagger;
+
+import com.ky.docstory.dto.repository.RepositoryResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "레포지토리 생성 응답 전체 구조")
+public class RepositoryCreateResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "100")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다.")
+    public String message;
+
+    @Schema(description = "실제 응답 데이터")
+    public RepositoryResponse data;
+}

--- a/src/main/java/com/ky/docstory/swagger/RoleUpdateResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/RoleUpdateResponseWrapper.java
@@ -1,0 +1,17 @@
+package com.ky.docstory.swagger;
+
+import com.ky.docstory.dto.team.RoleUpdateResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "팀원 권한 변경 응답 Wrapper")
+public class RoleUpdateResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "100")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다.")
+    public String message;
+
+    @Schema(description = "변경된 사용자 정보")
+    public RoleUpdateResponse data;
+}

--- a/src/main/java/com/ky/docstory/swagger/SuccessEmptyResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/SuccessEmptyResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.ky.docstory.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "성공했지만 반환 데이터가 없는 응답 Wrapper")
+public class SuccessEmptyResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "100")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다.")
+    public String message;
+
+    @Schema(description = "응답 데이터 (없음)", nullable = true)
+    public Object data;
+}

--- a/src/main/java/com/ky/docstory/swagger/TeamInviteResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/TeamInviteResponseWrapper.java
@@ -1,0 +1,17 @@
+package com.ky.docstory.swagger;
+
+import com.ky.docstory.dto.teaminvite.TeamInviteResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "팀 초대 응답 전체 구조")
+public class TeamInviteResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "100")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다.")
+    public String message;
+
+    @Schema(description = "실제 응답 데이터")
+    public TeamInviteResponse data;
+}

--- a/src/main/java/com/ky/docstory/swagger/TeamMemberListResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/TeamMemberListResponseWrapper.java
@@ -1,0 +1,19 @@
+package com.ky.docstory.swagger;
+
+import com.ky.docstory.dto.team.TeamMemberResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "팀원 목록 조회 응답 Wrapper")
+public class TeamMemberListResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "100")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다.")
+    public String message;
+
+    @Schema(description = "팀원 목록")
+    public List<TeamMemberResponse> data;
+}

--- a/src/main/java/com/ky/docstory/swagger/UnauthorizedErrorResponseWrapper.java
+++ b/src/main/java/com/ky/docstory/swagger/UnauthorizedErrorResponseWrapper.java
@@ -1,0 +1,16 @@
+package com.ky.docstory.swagger;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "401 인증 실패 응답")
+public class UnauthorizedErrorResponseWrapper {
+
+    @Schema(description = "응답 코드", example = "401")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = "인증에 실패했습니다.")
+    public String message;
+
+    @Schema(description = "응답 데이터", example = "null")
+    public Object data;
+}


### PR DESCRIPTION
## 📄요약

> Repository 및 Team API를 구현한다.

## 🖋️작업 내용

- [x] 팀 생성 ( -> Repository 생성)
- [x] 팀원 초대 ( -> Repository 초대)
- [x] 초대 수락 / 거절
- [x] 팀원 조회
- [x] 팀원 권한 처리
- [x] 레포지토리 리스트 조회

## 📷스크린샷
![image](https://github.com/user-attachments/assets/99fd32b7-c092-42bd-8d5d-17b5ac615135)


## ❗참고 사항


## 🔗이슈
close #20 
