### PR TITLE
[Fix]: URL로 액세스 토큰을 반환하도록 변경

### DIFF
--- a/src/main/java/com/ky/docstory/auth/CustomSuccessHandler.java
+++ b/src/main/java/com/ky/docstory/auth/CustomSuccessHandler.java
@@ -1,10 +1,11 @@
 package com.ky.docstory.auth;
 
 import com.ky.docstory.jwt.JWTUtil;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,9 +38,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         claims.put("profileImage", profileImage);
 
         String token = jwtUtil.createToken(claims);
-        Cookie jwtCookie = jwtUtil.createJwtCookie(token);
 
-        response.addCookie(jwtCookie);
-        response.sendRedirect(redirectUri);
+        String redirectWithToken = redirectUri + "?accessToken=" + URLEncoder.encode(token, StandardCharsets.UTF_8);
+        response.sendRedirect(redirectWithToken);
     }
 }


### PR DESCRIPTION
## 📄요약

> 기존의 쿠키 기반의 액세스 토큰 전달 방식을 쿼리 스트링 기반으로 변경한다.

## 🖋️작업 내용

- [x] 토큰을 URL 쿼리스트링 기반으로 전달하도록 변경

## 📷스크린샷
![image](https://github.com/user-attachments/assets/748c6466-7b0c-46e5-8edd-7c8d5a5b5e82)

## ❗참고 사항
https://www.notion.so/kanguk-room/1f2036cad7a880eab028fb515343691b?pvs=4

## 🔗이슈
close #42
