### PR TITLE
[Feat]: 소셜 로그인시 이메일을 저장하도록 로직 수정

### DIFF
--- a/src/main/java/com/ky/docstory/auth/CustomOAuth2User.java
+++ b/src/main/java/com/ky/docstory/auth/CustomOAuth2User.java
@@ -12,12 +12,15 @@ public class CustomOAuth2User implements OAuth2User {
     private final String providerId;
     private final String nickname;
     private final String profileImage;
+    private final String email;
 
-    public CustomOAuth2User(OAuth2User oAuth2User, String providerId, String nickname, String profileImage) {
+    public CustomOAuth2User(OAuth2User oAuth2User, String providerId, String nickname, String profileImage,
+                            String email) {
         this.oAuth2User = oAuth2User;
         this.providerId = providerId;
         this.nickname = nickname;
         this.profileImage = profileImage;
+        this.email = email;
     }
 
     @Override
@@ -45,5 +48,9 @@ public class CustomOAuth2User implements OAuth2User {
 
     public String getProfileImage() {
         return profileImage;
+    }
+
+    public String getEmail() {
+        return email;
     }
 }

--- a/src/main/java/com/ky/docstory/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/ky/docstory/auth/CustomOAuth2UserService.java
@@ -59,12 +59,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .nickname(userInfo.getNickname())
                     .profilePath(profileImage.getFilePath())
                     .profileFileName(profileImage.getSaveFilename())
+                    .email(userInfo.getEmail())
                     .build();
 
             user = userRepository.save(user);
         }
 
-        return new CustomOAuth2User(oAuth2User, user.getProviderId(), user.getNickname(), user.getProfilePath());
+        return new CustomOAuth2User(oAuth2User, user.getProviderId(), user.getNickname(), user.getProfilePath(), user.getEmail());
     }
 
     private ProfileImage uploadProfileImage(String socialFileUrl) throws IOException {

--- a/src/main/java/com/ky/docstory/auth/CustomSuccessHandler.java
+++ b/src/main/java/com/ky/docstory/auth/CustomSuccessHandler.java
@@ -31,11 +31,13 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String providerId = customOAuth2User.getProviderId();
         String nickname = customOAuth2User.getNickname();
         String profileImage = customOAuth2User.getProfileImage();
+        String email = customOAuth2User.getEmail();
 
         Map<String, Object> claims = new HashMap<>();
         claims.put("providerId", providerId);
         claims.put("nickname", nickname);
         claims.put("profileImage", profileImage);
+        claims.put("email", email);
 
         String token = jwtUtil.createToken(claims);
 

--- a/src/main/java/com/ky/docstory/auth/OAuth2UserDto.java
+++ b/src/main/java/com/ky/docstory/auth/OAuth2UserDto.java
@@ -17,6 +17,7 @@ public class OAuth2UserDto {
     private String providerId;
     private String nickname;
     private String profileImage;
+    private String email;
 
     public static OAuth2UserDto from(String registrationId, Map<String, Object> attributes) {
         if ("google".equals(registrationId)) {
@@ -33,16 +34,19 @@ public class OAuth2UserDto {
                 .providerId((String) attributes.get("sub"))
                 .nickname((String) attributes.get("name"))
                 .profileImage((String) attributes.get("picture"))
+                .email((String) attributes.get("email"))
                 .build();
     }
 
     private static OAuth2UserDto fromKakao(Map<String, Object> attributes) {
         Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
 
         return OAuth2UserDto.builder()
                 .providerId(attributes.get("id").toString())
                 .nickname((String) properties.get("nickname"))
                 .profileImage((String) properties.get("profile_image"))
+                .email((String) kakaoAccount.get("email"))
                 .build();
     }
 }

--- a/src/main/java/com/ky/docstory/dto/teaminvite/TeamInviteRequest.java
+++ b/src/main/java/com/ky/docstory/dto/teaminvite/TeamInviteRequest.java
@@ -1,6 +1,7 @@
 package com.ky.docstory.dto.teaminvite;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
@@ -12,7 +13,8 @@ public record TeamInviteRequest(
         @Schema(description = "레포지토리 ID", example = "7f310b23-f68d-4c4f-9910-94c96f00a4b2")
         UUID repositoryId,
 
-        @NotNull(message = "초대 대상 사용자 ID는 필수입니다.")
-        @Schema(description = "초대할 사용자 ID", example = "3e1192a9-3244-46ef-bc88-8de938974a9a")
-        UUID inviteeId
+        @NotNull(message = "초대 대상 사용자 이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이어야 합니다.")
+        @Schema(description = "초대할 사용자 이메일", example = "영진@example.com")
+        String email
 ) {}

--- a/src/main/java/com/ky/docstory/dto/user/UserResponse.java
+++ b/src/main/java/com/ky/docstory/dto/user/UserResponse.java
@@ -13,13 +13,17 @@ public record UserResponse(
         String nickname,
 
         @Schema(description = "현재 사용자 프로필 이미지", example = "인코딩된 프로필 이미지")
-        String profileImage
+        String profileImage,
+
+        @Schema(description = "현재 사용자 이메일", example = "영진@example.com")
+        String email
 ) {
     public static UserResponse from(User user, String profileImage) {
         return new UserResponse(
                 user.getProviderId(),
                 user.getNickname(),
-                profileImage
+                profileImage,
+                user.getEmail()
         );
     }
 }

--- a/src/main/java/com/ky/docstory/entity/User.java
+++ b/src/main/java/com/ky/docstory/entity/User.java
@@ -21,6 +21,8 @@ public class User extends BaseEntity {
 
     private String profileFileName;
 
+    private String email;
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/src/main/java/com/ky/docstory/repository/UserRepository.java
+++ b/src/main/java/com/ky/docstory/repository/UserRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByProviderId(String providerId);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteServiceImpl.java
+++ b/src/main/java/com/ky/docstory/service/teaminvite/TeamInviteServiceImpl.java
@@ -9,7 +9,6 @@ import com.ky.docstory.repository.RepositoryRepository;
 import com.ky.docstory.repository.TeamInviteRepository;
 import com.ky.docstory.repository.TeamRepository;
 import com.ky.docstory.repository.UserRepository;
-import com.ky.docstory.service.teaminvite.TeamInviteService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,11 +34,11 @@ public class TeamInviteServiceImpl implements TeamInviteService {
             throw new BusinessException(DocStoryResponseCode.FORBIDDEN);
         }
 
-        if (inviter.getId().equals(request.inviteeId())) {
+        if (inviter.getEmail().equals(request.email())) {
             throw new BusinessException(DocStoryResponseCode.PARAMETER_ERROR);
         }
 
-        User invitee = userRepository.findById(request.inviteeId())
+        User invitee = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new BusinessException(DocStoryResponseCode.NOT_FOUND));
 
         if (teamInviteRepository.existsByRepositoryAndInvitee(repository, invitee)) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,4 @@ spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kak
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+spring.security.oauth2.client.registration.kakao.scope=account_email,profile_nickname,profile_image


### PR DESCRIPTION
## 📄요약

> 프론트와의 API 연동 과정(내 정보, 팀원 초대)에서 이메일이 필요할 것으로 파악되어서 이메일을 소셜 로그인 시 받아오도록 로직을 수정한다.

## 🖋️작업 내용

- [x] 이메일을 저장하도록 로직 변경
- [x] 내 정보 조회, 팀원 초대 API에 email 추가

## 📷스크린샷
- 내 정보 조회 API
![image](https://github.com/user-attachments/assets/086ba2a2-6729-4a46-99f9-23557f3b0eff)

- 팀원 초대 API
![image](https://github.com/user-attachments/assets/798a1dda-6bc5-498a-9624-7a14ddf1b1bf)


## ❗참고 사항


## 🔗이슈
close #44
