### PR TITLE
[Feat]: 팀원 조회 response에 email 추가

### DIFF
--- a/src/main/java/com/ky/docstory/dto/team/TeamMemberResponse.java
+++ b/src/main/java/com/ky/docstory/dto/team/TeamMemberResponse.java
@@ -17,6 +17,9 @@ public record TeamMemberResponse(
         @Schema(description = "프로필 이미지 경로", example = "https://example.com/profile.jpg")
         String profileImage,
 
+        @Schema(description = "팀원 이메일", example = "kanguk@example.com")
+        String email,
+
         @Schema(description = "팀원 역할", example = "CONTRIBUTOR")
         String role
 ) {
@@ -25,6 +28,7 @@ public record TeamMemberResponse(
                 team.getUser().getId(),
                 team.getUser().getNickname(),
                 team.getUser().getProfilePath(),
+                team.getUser().getEmail(),
                 team.getRole().name()
         );
     }


### PR DESCRIPTION
## 📄요약

> 프론트 팀원 조회 모달에서 이메일을 띄우기 위해서 팀원 조회 response에 email 필드를 추가한다.

## 🖋️작업 내용

- [x] 팀원 조회 responseDto에 email 필드 추가 

## 📷스크린샷
![image](https://github.com/user-attachments/assets/678df9da-d5ca-4628-9262-562061a5a917)

## ❗참고 사항

## 🔗이슈
close #45
