### PR TITLE
[Fix]: 히스토리 상세 조회 시 상위 레벨의 파일들이 모두 조회되는 현상

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ fabric.properties
 
 !.idea/codeStyles
 !.idea/runConfigurations
+.cursor/
+.vscode/
 
 ### Java ###
 # Compiled class file
@@ -194,6 +196,7 @@ $RECYCLE.BIN/
 **/build/
 !src/**/build/
 
+
 # Ignore Gradle GUI config
 gradle-app.setting
 
@@ -222,3 +225,4 @@ gradle-app.setting
 src/main/resources/env-dev.properties
 src/main/resources/env-prod.properties
 .env
+

--- a/src/main/java/com/ky/docstory/service/history/HistoryServiceImpl.java
+++ b/src/main/java/com/ky/docstory/service/history/HistoryServiceImpl.java
@@ -122,7 +122,7 @@ public class HistoryServiceImpl implements HistoryService {
 
         History savedHistory = getHistoryByIdOrThrow(historyId);
 
-        List<FileResponse> fileResponses = getFileResponseTreeFromChild(savedHistory.getFile());
+        List<FileResponse> fileResponses = List.of(FileResponse.from(savedHistory.getFile()));
 
         UserResponse userResponse = userService.getUserInfo(savedHistory.getCreatedBy());
 


### PR DESCRIPTION
## 📄요약

> 히스토리 상세 조회 시 상위 레벨의 파일들이 모두 조회되는 현상

## 🖋️작업 내용

- [x] 메소드 수정

## 📷스크린샷
<img width="810" alt="image" src="https://github.com/user-attachments/assets/c9cb8e67-3d0d-4ca2-b17b-c4b52f604c3a" />


## ❗참고 사항


## 🔗이슈
close #52 
